### PR TITLE
build(deps): bump unimport from 1.2.1 to 1.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,9 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.2.1
+    rev: 1.3.0
     hooks:
       - id: unimport
-        language_version: python3.12
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1
     hooks:


### PR DESCRIPTION
remove the language_version key now unimport is compatible with 3.13
